### PR TITLE
Fix harmonyMaster for 3.7.

### DIFF
--- a/HelpSource/Guides/04-Auxiliary_Tools.schelp
+++ b/HelpSource/Guides/04-Auxiliary_Tools.schelp
@@ -28,7 +28,7 @@ Pdef(\harmonyMaster, Pbind(
     \type, \mandelspace,
     \deltaSched, 1,
     \mtranspose, 0,
-    \scale, \minor,
+    \scale, Scale.minor,
     \tuning, \et12,
     \root, 0,
     \dur, 4
@@ -55,24 +55,24 @@ Pdef(\hmTest).play;
 )
 ::
 
-Now change some values in the harmonyMaster Pdef (e.g. \major instead of \minor) and you can hear the harmonic changes.
+Now change some values in the harmonyMaster Pdef (e.g. Scale.major instead of Scale.minor) and you can hear the harmonic changes.
 
 To be even more musical there is a magic code::\harmony:: key in code::\mandelspace:: events. It takes two kinds of notation and sets code::\ctranspose:: and code::\scale:: accordingly.
 
 Notation 1 takes Symbols from roman number analysis (based on c-major). You can add a STRONG::s:: or STRONG::b:: at the end to add an accidential.
 
 LIST::
-## STRONG::\V::    --> ctranspose: 7, scale: \major
-## STRONG::\iii::  --> ctranspose: 4, scale: \minor
-## STRONG::\IIIb:: --> ctranspose: 3, scale: \major
+## STRONG::\V::    --> ctranspose: 7, scale: Scale.major
+## STRONG::\iii::  --> ctranspose: 4, scale: Scale.minor
+## STRONG::\IIIb:: --> ctranspose: 3, scale: Scale.major
 ::
 
 Notation 2 just mixes the root number with a uppercase M for major and a downcase m for minor:
 
 LIST::
-## STRONG::\M7::   --> ctranspose: 7, scale: \major
-## STRONG::\m4::   --> ctranspose: 4, scale: \minor
-## STRONG::\M3::   --> ctranspose: 3, scale: \major
+## STRONG::\M7::   --> ctranspose: 7, scale: Scale.major
+## STRONG::\m4::   --> ctranspose: 4, scale: Scale.minor
+## STRONG::\M3::   --> ctranspose: 3, scale: Scale.major
 ::
 
 code::

--- a/MandelSpace.sc
+++ b/MandelSpace.sc
@@ -2,36 +2,36 @@
 	MandelSpace
 	(c) 2011 by Patrick Borgeat <patrick@borgeat.de>
 	http://www.cappel-nord.de
-	
+
 	Part of BenoitLib
 	http://github.com/cappelnord/BenoitLib
 	http://www.the-mandelbrots.de
-	
+
 	Shared Variable Space used by MandelHub
-	
+
 */
 
 MandelSpace : MandelModule {
-	
+
 	var <objects;
 	var <hub;
-	
+
 	var <>allowRemoteCode = false;
-	
+
 	var envirInstance;
-		
+
 	var <quant;
-	
+
 	classvar defaultDictInstance;
-	
+
 	var healSJ;
-	
+
 	var updateSink = nil;
-	
+
 	*new {|hub|
-		^super.new.init(hub);	
+		^super.new.init(hub);
 	}
-	
+
 	*getValueOrDefault {|key|
 		MandelHub.instance.notNil.if {
 			^MandelHub.instance.space.getValue(key);
@@ -39,11 +39,11 @@ MandelSpace : MandelModule {
 			^MandelSpace.defaultDict.at(key);
 		}
 	}
-	
+
 	*defaultDict {
 		defaultDictInstance.isNil.if {
 			defaultDictInstance = (
-				scale: \minor,
+				scale: Scale.minor,
 				tuning: \et12,
 				mtranspose: 0,
 				ctranspose: 0,
@@ -52,19 +52,19 @@ MandelSpace : MandelModule {
 				octaveRatio: 2
 			);
 		};
-		^defaultDictInstance;	
+		^defaultDictInstance;
 	}
-	
+
 	asDict {
 		var dict = Dictionary.new;
-		
+
 		objects.do {|obj|
-			dict.put(obj.key, obj.getValue());	
+			dict.put(obj.key, obj.getValue());
 		};
-		
+
 		^dict;
 	}
-	
+
 	// TODO: prettify
 	dumpValues {
 		"Dumping all MandelSpace Values: ".postln;
@@ -84,24 +84,24 @@ MandelSpace : MandelModule {
 		};
 		"\n".post;
 	}
-	
+
 	quant_ {|val|
-		quant = val.asQuant;	
+		quant = val.asQuant;
 	}
-	
+
 	init {|a_hub|
-		hub = a_hub;	
-					
+		hub = a_hub;
+
 		objects = Dictionary.new;
-		
+
 		this.prBuildEvents();
 		this.prSetDefaults();
 		this.prCreateFreqValues();
-		
+
 		this.prStartHealSJ;
 
 	}
-	
+
 	prStartHealSJ {
 		// all keys that can be healed
 		var keyStreamFunc = {
@@ -112,9 +112,9 @@ MandelSpace : MandelModule {
 				nil;
 			});
 		};
-		
+
 		var keyStream = keyStreamFunc.value;
-		
+
 		healSJ = SkipJack({
 			var nextKey = keyStream.next;
 			nextKey.isNil.if({
@@ -122,15 +122,15 @@ MandelSpace : MandelModule {
 			}, {
 				this.sendHealValue(nextKey);
 			});
-		},3.5, name: "MandelSpaceHealing");	
+		},3.5, name: "MandelSpaceHealing");
 	}
-	
+
 	prSetDefaults {
 		MandelSpace.defaultDict.keys.do {|key|
 			this.getObject(key).setValue(MandelSpace.defaultDict.at(key), -1, doSend:false);
 		}
 	}
-	
+
 	prBuildEvents {
 		var degreeDict = (
 			\i: 0,
@@ -139,15 +139,15 @@ MandelSpace : MandelModule {
 			\iv: 5,
 			\v: 7,
 			\vi: 9,
-			\vii: 11	
+			\vii: 11
 		);
 		var decodeHarmony = {|x|
 			var xs = x.asString;
 			var firstChar = xs[0];
-			var scale = \minor;
+			var scale = Scale.minor;
 			var ct = 0;
-			firstChar.isUpper.if({scale = \major;});
-	
+			firstChar.isUpper.if({scale = Scale.major;});
+
 			((firstChar == $m) || (firstChar == $M)).if({
 				ct = xs[1..].asInteger;
 			}, {
@@ -160,23 +160,23 @@ MandelSpace : MandelModule {
 			});
 			[ct, scale];
 		};
-		
+
 		Event.addEventType(\mandelspace, {
 			var schedBeats;
 			var strategy = \time;
 			var list = List.new;
 			~deltaSched = ~deltaSched ? 0.0;
 			~beats = ~beats ? hub.clock.beats;
-			
+
 			schedBeats = ~beats + ~deltaSched;
-			
+
 			(schedBeats <= hub.clock.beats).if {
 				schedBeats = 0.0; // no scheduling
 			};
-			
+
 			// stream values if duration is short
 			((~dur <= 0.1) && (schedBeats == 0.0)).if {
-				strategy = \stream;	
+				strategy = \stream;
 			};
 
 			if(currentEnvironment[\harmony] != nil) {
@@ -188,7 +188,7 @@ MandelSpace : MandelModule {
 					("Could not decode harmony: " ++ currentEnvironment[\harmony]).error;
 				});
 			};
-			
+
 			currentEnvironment.keys.do {|key|
 				#[\type, \dur, \removeFromCleanup, \deltaSched, \beats, \harmony].includes(key).not.if {
 					list.add(key);
@@ -201,56 +201,56 @@ MandelSpace : MandelModule {
 			};
 		});
 	}
-	
+
 	getObject {|key|
 		var obj = objects.at(key.asSymbol);
-		
+
 		obj.isNil.if {
 			obj = MandelValue(this, key);
 			objects.put(key.asSymbol, obj);
 		}
 		^obj;
 	}
-	
+
 	getValue {|key, useDecorator=true|
 		var obj = this.getObject(key);
 		^obj.getValue(useDecorator);
 	}
-	
+
 	setValue {|key, value, schedBeats, strategy=\time|
 		var obj;
-		
+
 		key.isNil.if {
 			("Invalid key: " ++ key).error;
-			^nil;	
+			^nil;
 		};
-		
+
 		key = key.asSymbol;
-		
+
 		obj = this.getObject(key);
 		obj.setValue(value, schedBeats, strategy:strategy);
 	}
-	
+
 	setValueList {|keyValueList, schedBeats, strategy=\time|
 		var cleanList = List.new;
-		
+
 		this.prStartUpdateSink;
 		(0,2..(keyValueList.size-1)).do {|i|
 			var key = keyValueList[i];
 			var value = keyValueList[i+1];
-				
+
 			key.isNil.if ({/* NOOP */}, {
 				key = key.asSymbol;
 				this.getObject(key).setValue(value, schedBeats, doSend: false);
 				cleanList.add(key);
 				cleanList.add(value);
 			});
-		};		
+		};
 		this.prFinishUpdateSink;
-		
+
 		this.sendValue(cleanList, schedBeats, strategy);
 	}
-	
+
 	sendValue {|keyValueList, schedBeats=0.0, strategy=\time|
 		var delta = schedBeats - hub.clock.beats;
 		var burstNum = 2;
@@ -258,7 +258,7 @@ MandelSpace : MandelModule {
 		var oi = 0;
 		var serSlots;
 		keyValueList = Array.newClear(origList.size / 2 * 3);
-		
+
 		// encode data
 		(0,3..(keyValueList.size-1)).do {|i|
 			keyValueList[i] = origList[oi].asString;
@@ -267,9 +267,9 @@ MandelSpace : MandelModule {
 			keyValueList[i+2] = serSlots[1];
 			oi = oi + 2;
 		};
-		
+
 		schedBeats = schedBeats.asFloat;
-		
+
 		(delta < 0.25).if ({
 			(strategy == \stream).if {
 				hub.net.sendMsgCmd("/value", schedBeats, *keyValueList);
@@ -285,7 +285,7 @@ MandelSpace : MandelModule {
 			hub.net.sendMsgBurst("/value", [burstNum, delta], schedBeats, *keyValueList);
 		});
 	}
-	
+
 	sendHealValue {|key|
 		var obj = this.getObject(key);
 		var serSlots;
@@ -294,64 +294,66 @@ MandelSpace : MandelModule {
 			hub.net.sendMsgBurst("/healValue", \relaxed, obj.bdl.setAtBeat.asFloat, key.asString, serSlots[0], serSlots[1]);
 		};
 	}
-	
+
 	// dict interface
 	at {|key|
-		^this.getObject(key);	
+		^this.getObject(key);
 	}
-	
+
 	put {|key, value|
-		^this.setValue(key, value);	
+		^this.setValue(key, value);
 	}
-	
+
 	removeAt {|key|
-		// to implement	
+		// to implement
 	}
-	
+
 	// code to string if not a native osc type
 	serialize {|value|
 		value.isInteger.if {^[0, value]};
 		value.isFloat.if {^[0, value]};
 		value.isString.if {^[0, value]};
 		value.isKindOf(Symbol).if {^["SM", value.asString]};
+		value.isKindOf(Scale).if {^["SC", value.asCompileString]};
 		value.isNil.if {^["NL", ""]};
-		
+
 		value.isFunction.if {
 			value.isClosed.if({
 				^["CS", value.asCompileString];
 			},{
-				Error("Only closed functions can be sent through MandelSpace").throw;	
+				Error("Only closed functions can be sent through MandelSpace").throw;
 			});
 		};
-		
+
 		"There is no explicit rule to send the object through MandelSpace - trying asCompileString".warn;
 		("Compile String: " ++ value.asCompileString).postln;
 		// ("Key: " ++ key).postln;
 		^["CS", value.asCompileString];
 	}
-	
+
 	// build object if object was serialized
 	deserialize {|serType, value|
 		var payload;
 		value.isNumber.if {^value};
 		(serType == \NL).if {^nil;};
-		
+
 		value.isKindOf(Symbol).if {
 			((serType == 0) || (serType == '')).if {^value.asString;};
 			(serType == \SM).if {^value.asSymbol;};
+			(serType == \SC).if {^value.asString.interpret;};
 			(serType == \CS).if {
 				allowRemoteCode.if({
 					^value.asString.interpret;
 				}, {
 					"MandelSpace received remote code but wasn't allowed to execute.\nSet allowRemoteCode to true if you know what you're doing!".warn;
-				});	
-			};	
+				});
+			};
 		};
-		
+
 		// if everything else fails ...
 		^value.asString;
 	}
-	
+
 	onSyncRequest {|hub|
 		{
 			0.1.wait;
@@ -370,24 +372,24 @@ MandelSpace : MandelModule {
 			};
 		}.fork; // delay a little bit and add wait time
 	}
-	
+
 	onStartup {|hub|
 		hub.net.addOSCResponder(\general, "/value", {|header, payload|
 			var name = header.name;
 			var schedBeats = payload[0].asFloat;
-			
+
 			this.prStartUpdateSink;
 			(1,4..(payload.size-1)).do {|i|
 				var key = payload[i].asSymbol;
 				var value = this.deserialize(payload[i+1], payload[i+2]);
 				// ("Key: " ++ key).postln;
-				// ("Value: " ++ value).postln; 
+				// ("Value: " ++ value).postln;
 				this.getObject(key).setValue(value, schedBeats, header.name, doSend:false);
 			};
 			this.prFinishUpdateSink;
-			
+
 		}, \dropOwn);
-		
+
 		hub.net.addOSCResponder(\general, "/healValue", {|header, payload|
 			var schedBeats = payload[0].asFloat;
 			var key = payload[1].asSymbol;
@@ -395,23 +397,23 @@ MandelSpace : MandelModule {
 			this.getObject(key).tryHealValue(value, schedBeats, header.name);
 		}, \dropOwn);
 	}
-	
+
 	envir {
 		envirInstance.isNil.if {
 			envirInstance = MandelEnvironment(this);
 		};
-		^envirInstance;	
+		^envirInstance;
 	}
-	
+
 	prCreateFreqValues {|lag=0.0|
 		var scale = PmanScale().asStream;
 		var relations = [\scale, \tuning, \root, \stepsPerOctave, \octaveRatio];
 		var stdValues = [\root, \stepsPerOctave, \octaveRatio];
-		
+
 		var rootFreq = this.getObject(\rootFreq);
 		var mtransposeFreq = this.getObject(\mtransposeFreq);
 		var ctransposeFreq = this.getObject(\ctransposeFreq);
-		
+
 		var stdEvent = {
 			var ev = Event.partialEvents[\pitchEvent].copy;
 			stdValues.do {|item|
@@ -425,76 +427,76 @@ MandelSpace : MandelModule {
 			var obj = this.getObject(item);
 			obj.addDependant(rootFreq);
 		};
-		
+
 		rootFreq.addDependant(mtransposeFreq);
 		rootFreq.addDependant(ctransposeFreq);
-		
+
 		this.getObject(\mtranspose).addDependant(mtransposeFreq);
 		this.getObject(\ctranspose).addDependant(ctransposeFreq);
-		
+
 		rootFreq.decorator = {
 			var ev = stdEvent.value();
 			ev.use {~freq.value()};
 		};
-		
+
 		mtransposeFreq.decorator = {
 			var ev = stdEvent.value();
 			ev[\mtranspose] = 	this.getValue(\mtranspose);
 			ev.use {~freq.value()};
 		};
-		
+
 		ctransposeFreq.decorator = {
 			var ev = stdEvent.value();
 			ev[\ctranspose] = 	this.getValue(\ctranspose);
 			ev.use {~freq.value()};
 		};
 	}
-	
+
 	freeAllRessources {
 		objects.do {|item|
 			item.freeRessources;
 		};
 	}
-	
+
 	onClear {|hub|
 		this.freeAllRessources;
 		healSJ.stop;
 	}
-	
+
 	keys {
-		^objects.keys;	
+		^objects.keys;
 	}
-	
+
 	prStartUpdateSink {
-		updateSink = IdentityDictionary();	
+		updateSink = IdentityDictionary();
 	}
-	
+
 	prScheduleUpdate {|key, func|
 		updateSink.isNil.if({
 			func.value();
 		}, {
 			updateSink[key].isNil.if {
-				updateSink[key] = func;	
+				updateSink[key] = func;
 			};
 		});
 	}
-	
+
 	prFinishUpdateSink {
 		var oldSink = updateSink;
 		updateSink = IdentityDictionary.new;
-		
+
 		oldSink.keys.do {|key|
-			updateSink[key] = 0;	
+			updateSink[key] = 0;
 		};
-		
+
 		oldSink.values.do {|item|
-			item.value();	
+			item.value();
 		};
-		
+
 		(updateSink.size > oldSink.size).if {
-			this.prFinishUpdateSink;	
+			this.prFinishUpdateSink;
 		};
-				
-		updateSink = nil;	
+
+		updateSink = nil;
 	}
 }

--- a/patterns/Pman.sc
+++ b/patterns/Pman.sc
@@ -33,7 +33,7 @@ PmanScale : Pattern {
 	// can be seen as a Singleton every PmanScale instance should behave the same at a given time.
 
 	// Saving this as a classvar doesn't reset the scale at instantiation.
-	classvar lastScaleKey = Scale.minor;
+	classvar lastScaleKey = \minor;
 
 	embedInStream {|event|
 		var scaleKey, tuningKey, scale;

--- a/patterns/Pman.sc
+++ b/patterns/Pman.sc
@@ -2,24 +2,24 @@
 	Pman
 	(c) 2011 by Patrick Borgeat <patrick@borgeat.de>
 	http://www.cappel-nord.de
-	
+
 	Part of BenoitLib
 	http://github.com/cappelnord/BenoitLib
 	http://www.the-mandelbrots.de
-	
+
 	A stream of shared MandelSpace values.
-	
+
 */
 
 Pman : Pattern {
 
 	var <>key;
-	
+
 	*new {|key|
 		^super.new.key_(key);
 	}
-	
-	embedInStream {|event|		
+
+	embedInStream {|event|
 		while {true} {
 			MandelSpace.getValueOrDefault(key).yield;
 		};
@@ -28,17 +28,17 @@ Pman : Pattern {
 }
 
 PmanScale : Pattern {
-	
+
 	// this is a bad design decision but more practiable. As MandelHub and MandelSpace
 	// can be seen as a Singleton every PmanScale instance should behave the same at a given time.
-	
+
 	// Saving this as a classvar doesn't reset the scale at instantiation.
-	classvar lastScaleKey = \minor;
-	
+	classvar lastScaleKey = Scale.minor;
+
 	embedInStream {|event|
-		var scaleKey, tuningKey, scale;		
+		var scaleKey, tuningKey, scale;
 		while {true} {
-			scaleKey = MandelSpace.getValueOrDefault(\scale).asSymbol;
+			scaleKey = MandelSpace.getValueOrDefault(\scale);
 			tuningKey  = MandelSpace.getValueOrDefault(\tuning).asSymbol;
 
 			Main.versionAtLeast(3,7).if({
@@ -50,17 +50,25 @@ PmanScale : Pattern {
 				"PmanScale: Falling back to default tuning ...".postln;
 				tuningKey = nil;
 			};
-			
-			scale = Scale.newFromKey(scaleKey, tuningKey);
-			scale.isNil.if ({
-				scale = Scale.newFromKey(lastScaleKey, tuningKey);
-				("PmanScale: Falling back to last valid scale in this stream: " ++ lastScaleKey.asString).postln;
+
+			scaleKey.isKindOf(Scale).if({
+				scale = scaleKey;
+				tuningKey.notNil.if({
+					scale.tuning_(tuningKey);
+				});
+				lastScaleKey = scaleKey;
 			}, {
-				lastScaleKey = scaleKey;	
-			});	
-					
+				scale = Scale.newFromKey(scaleKey.asSymbol, tuningKey);
+				scale.isNil.if ({
+					scale = Scale.newFromKey(lastScaleKey.asSymbol, tuningKey);
+					("PmanScale: Falling back to last valid scale in this stream: " ++ lastScaleKey.asString).postln;
+				}, {
+					lastScaleKey = scaleKey;
+				});
+			});
+
 			scale.yield;
 		};
 		^event;
-	}	
+	}
 }


### PR DESCRIPTION
- use Scale instances instead of symbols
- add special case for serializing them for OSC
- if a \tuning is provided, replace Scale's tuning with it
- updated documentation
- SCIDE seems to mess with whitespace, sorry about that x
